### PR TITLE
Handle empty query list in encoded_of_query

### DIFF
--- a/lib_re/uri_legacy.ml
+++ b/lib_re/uri_legacy.ml
@@ -579,20 +579,31 @@ module Query = struct
    * this function.
   *)
   let encoded_of_query ?scheme l =
-    let len = List.fold_left (fun a (k,v) ->
-        a + (String.length k)
-        + (List.fold_left (fun a s -> a+(String.length s)+1) 0 v) + 2) (-1) l in
-    let buf = Buffer.create len in
-    iter_concat (fun buf (k,v) ->
-        Buffer.add_string buf (pct_encode ?scheme ~component:`Query_key k);
-        if v <> [] then (
-          Buffer.add_char buf '=';
-          iter_concat (fun buf s ->
-              Buffer.add_string buf
-                (pct_encode ?scheme ~component:`Query_value s)
-            ) "," buf v)
-      ) "&" buf l;
-    Buffer.contents buf
+    match l with
+    | [] -> ""
+    | l ->
+      let len =
+        List.fold_left
+          (fun a (k, v) ->
+             a + String.length k
+             + (List.fold_left (fun a s -> a + String.length s + 1) 0 v)
+             + 2)
+          0 l - 1
+      in
+      let buf = Buffer.create len in
+      iter_concat
+        (fun buf (k, v) ->
+           Buffer.add_string buf
+             (pct_encode ?scheme ~component:`Query_key k);
+           if v <> [] then (
+             Buffer.add_char buf '=';
+             iter_concat
+               (fun buf s ->
+                  Buffer.add_string buf
+                    (pct_encode ?scheme ~component:`Query_value s))
+               "," buf v))
+        "&" buf l;
+      Buffer.contents buf
 
   let of_raw qs =
     let lazy_query = Lazy.from_fun (fun () -> query_of_encoded qs) in


### PR DESCRIPTION
## Summary
- avoid negative buffer allocation for empty query lists

## Testing
- `dune runtest` *(fails: Library "crowbar" not found; Library "ounit2" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f033e5d4832b938b3332cabd1538